### PR TITLE
RendererOptions erste Implementation

### DIFF
--- a/apps/src/main/java/cgresearch/apps/options/RendererOptionsExample.java
+++ b/apps/src/main/java/cgresearch/apps/options/RendererOptionsExample.java
@@ -1,0 +1,38 @@
+package cgresearch.apps.options;
+
+import cgresearch.AppLauncher;
+import cgresearch.JoglAppLauncher;
+import cgresearch.core.assets.ResourcesLocator;
+import cgresearch.core.math.VectorFactory;
+import cgresearch.graphics.bricks.CgApplication;
+
+
+/**
+ * Sample app that showcases the renderer options interface.
+ * All this app does is paint an empty scene with a black background instead of
+ * the default white one.
+ * Created by christian on 18.06.16.
+ */
+public class RendererOptionsExample extends CgApplication {
+
+    public RendererOptionsExample() {
+        //set the background to black
+
+        //set up the necessary renderer options
+        //set them in the root node of the scene graph so that the renderer
+        // can access them
+        getCgRootNode().getRendererOptions().
+                setClearColor(VectorFactory.
+                        createVector3(1,0,0)); // default is (1,1,1)
+    }
+
+    public static void main(String[] args) {
+        ResourcesLocator.getInstance().parseIniFile("resources.ini");
+        CgApplication app = new RendererOptionsExample();
+        JoglAppLauncher appLauncher = JoglAppLauncher.getInstance();
+        appLauncher.create(app);
+        appLauncher.setRenderSystem(AppLauncher.RenderSystem.JOGL);
+        appLauncher.setUiSystem(AppLauncher.UI.JOGL_SWING);
+    }
+
+}

--- a/apps/src/main/java/cgresearch/apps/options/RendererOptionsExample.java
+++ b/apps/src/main/java/cgresearch/apps/options/RendererOptionsExample.java
@@ -23,7 +23,7 @@ public class RendererOptionsExample extends CgApplication {
         // can access them
         getCgRootNode().getRendererOptions().
                 setClearColor(VectorFactory.
-                        createVector3(1,0,0)); // default is (1,1,1)
+                        createVector3(0,0,0)); // default is (1,1,1)
     }
 
     public static void main(String[] args) {

--- a/graphics_core/src/main/java/cgresearch/graphics/scenegraph/CgNode.java
+++ b/graphics_core/src/main/java/cgresearch/graphics/scenegraph/CgNode.java
@@ -12,6 +12,7 @@ import java.util.Observable;
 import java.util.Observer;
 
 import cgresearch.core.math.BoundingBox;
+import cgresearch.rendering.core.RendererOptions;
 
 /**
  * Representation of a generic node in the scene graph
@@ -55,6 +56,11 @@ public class CgNode extends Observable implements Observer {
    * Visibility of the node.
    */
   private boolean visible = true;
+
+  /**
+   * Renderer options for the node.
+   */
+  protected RendererOptions rendererOptions;
 
   /**
    * Default constructor
@@ -272,5 +278,13 @@ public class CgNode extends Observable implements Observer {
 
   public void setContent(ICgNodeContent content) {
     this.content = content;
+  }
+
+  /**
+   * Getter.
+   * @return the renderer options object associated with this node
+     */
+  public RendererOptions getRendererOptions() {
+    return rendererOptions;
   }
 }

--- a/graphics_core/src/main/java/cgresearch/graphics/scenegraph/CgRootNode.java
+++ b/graphics_core/src/main/java/cgresearch/graphics/scenegraph/CgRootNode.java
@@ -1,5 +1,7 @@
 package cgresearch.graphics.scenegraph;
 
+import cgresearch.rendering.core.RendererOptions;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -42,6 +44,9 @@ public class CgRootNode extends CgNode {
    */
   public CgRootNode() {
     super(null, "root");
+
+    //Set the default renderer options.
+    rendererOptions = RendererOptions.defaultRendererOptions();
   }
 
   /**

--- a/graphics_core/src/main/java/cgresearch/rendering/core/RendererOptions.java
+++ b/graphics_core/src/main/java/cgresearch/rendering/core/RendererOptions.java
@@ -1,0 +1,42 @@
+package cgresearch.rendering.core;
+
+import cgresearch.core.math.Vector;
+import cgresearch.core.math.VectorFactory;
+
+/**
+ * This class provides an interface for changing certain parameters that were hard-coded constants of the renderer.
+ * It was designed to be able to change the background colour of the scene.
+ * Created by christian on 18.06.16.
+ */
+public class RendererOptions {
+    /**
+     * Default clear color.
+     */
+    static final Vector CLEAR_COLOR = VectorFactory.createVector3(1, 1, 1);
+    //TODO move default constants from JoglRenderer3D to here
+
+    /**
+     * Set up the clear color of the scene.
+     */
+    private Vector clearColor = new Vector(CLEAR_COLOR);
+
+    /**
+     * Getter.
+     * @return the current clear color
+     */
+    public Vector getClearColor() {
+        return clearColor;
+    }
+
+    /**
+     * Setter.
+     * @param clearColor the new clear color
+     */
+    public void setClearColor(Vector clearColor) {
+        this.clearColor = clearColor;
+    }
+
+    public static RendererOptions defaultRendererOptions() {
+        return new RendererOptions();
+    }
+}

--- a/rendering_jogl/src/main/java/cgresearch/rendering/jogl/core/JoglRenderer3D.java
+++ b/rendering_jogl/src/main/java/cgresearch/rendering/jogl/core/JoglRenderer3D.java
@@ -17,6 +17,7 @@ import cgresearch.core.math.*;
 import cgresearch.graphics.camera.Camera;
 import cgresearch.graphics.misc.AnimationTimer;
 import cgresearch.graphics.scenegraph.*;
+import cgresearch.rendering.core.RendererOptions;
 import cgresearch.rendering.jogl.misc.PickingRenderer;
 import cgresearch.rendering.jogl.misc.ViewFrustumCulling;
 
@@ -45,7 +46,6 @@ public class JoglRenderer3D implements Observer {
   private static final int SCREEN_WIDTH = 640;
   private static final int SCREEN_HEIGHT = 480;
   private static final float OPAQUE = 1.0f;
-  private static final Vector CLEAR_COLOR = VectorFactory.createVector3(1, 1, 1);
   private static final int JOGL_NUMBER_OF_LIGHTS = 8;
 
   /**
@@ -136,6 +136,11 @@ public class JoglRenderer3D implements Observer {
   private final ViewFrustumCulling viewFrustum;
 
   /**
+   * Access to the renderer options interface.
+   */
+  private RendererOptions rendererOptions;
+
+  /**
    * Constructor.
    */
   public JoglRenderer3D(JoglRenderObjectManager renderObjectManager, CgRootNode rootNode) {
@@ -146,6 +151,7 @@ public class JoglRenderer3D implements Observer {
     rootNode.addObserver(this);
     Camera.getInstance().addObserver(this);
     glu = new GLU();
+    rendererOptions = rootNode.getRendererOptions();
   }
 
   public void init(GLAutoDrawable drawable) {
@@ -177,7 +183,7 @@ public class JoglRenderer3D implements Observer {
     gl.glEnableClientState(GLPointerFunc.GL_COLOR_ARRAY);
 
     // define the color we want to be displayed as the "clipping wall"
-    gl.glClearColor((float) (CLEAR_COLOR.get(0)), (float) (CLEAR_COLOR.get(1)), (float) (CLEAR_COLOR.get(2)), OPAQUE);
+    gl.glClearColor((float) (rendererOptions.getClearColor().get(0)), (float) (rendererOptions.getClearColor().get(1)), (float) (rendererOptions.getClearColor().get(2)), OPAQUE);
 
     // Enable lighting
     gl.glEnable(GL2.GL_LIGHTING);


### PR DESCRIPTION
Hallo,

Als ich angefangen habe, Prototypen zu schreiben, habe ich gemerkt, dass einige Sachen im Renderer hart kodiert sind, welche man vielleicht doch gerne ändern möchte. 

Nach einem Austausch mit Professor Jenke hat er mir geraten, dass ich das ändern könnte, so dass man z.B die "clear color" (die Hintergrundfarbe) im Szenengraph ändern kann. Hier ist ein erster Umbau des Codes in diese Richtung, welche mit bestehendem Code funktionieren sollte. Momentan kann man nur die Hintergrundfarbe der Szene ändern (alles andere ist immer noch im Renderer hard-kodiert) , aber die Klasse "RendererOptions" lässt sich bei Bedarf erweitern. 

Bitte um Kommentare und Anregungen! 

Beste Grüße, 

Christian Schirin